### PR TITLE
Remove dependency on 2nd major version of RSpec

### DIFF
--- a/mas-development_dependencies.gemspec
+++ b/mas-development_dependencies.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'pry-rails'
   spec.add_dependency 'pry-rescue'
   spec.add_dependency 'rack-livereload'
-  spec.add_dependency 'rspec-rails', '~> 2.0'
+  spec.add_dependency 'rspec-rails', '>= 2.0'
   spec.add_dependency 'shoulda-matchers'
   spec.add_dependency 'site_prism'
   spec.add_dependency 'timecop'


### PR DESCRIPTION
RSpec 3 is on the horizon.
