### PR TITLE
Ensure the karma and npm commands' exit status is returned by Rake

### DIFF
--- a/lib/mas/development_dependencies/karma.rb
+++ b/lib/mas/development_dependencies/karma.rb
@@ -38,7 +38,7 @@ module MAS
               Tempfile.open('karma_unit.js', File.expand_path('tmp')) do |f|
                 f.write unit_js(application_spec_files)
                 f.flush
-                system "./node_modules/karma/bin/karma #{command} #{f.path} #{args}"
+                sh "./node_modules/karma/bin/karma #{command} #{f.path} #{args}"
               end
             end
 
@@ -55,7 +55,7 @@ module MAS
             end
 
             def install_modules
-              system "npm install"
+              sh "npm install"
             end
 
           end


### PR DESCRIPTION
Running tests using the `rake karma:run_once` task was silently ignoring build failures because the karma command's exit status was being ignored.

`system` was being used to run Karma. Although `system` returns false if
the command it executes returns a non-zero exit status, this was not
causing Rake to propagate the failure.

Swapped to use Rake's `sh` call instead.

http://www.ruby-doc.org/stdlib-2.1.2/libdoc/rake/rdoc/FileUtils.html#method-i-sh
http://www.ruby-doc.org/core-2.1.2/Kernel.html#method-i-system
