### PR TITLE
Add a rails generator for copying across our generic rubocop config file

### DIFF
--- a/lib/generators/money_advice_service/rubocop/install_generator.rb
+++ b/lib/generators/money_advice_service/rubocop/install_generator.rb
@@ -1,0 +1,12 @@
+module MoneyAdviceService
+  module Rubocop
+    class InstallGenerator < ::Rails::Generators::Base
+      source_root File.expand_path('../templates', __FILE__)
+      desc 'Install rubocop config file'
+
+      def copy_config_file
+        copy_file 'rubocop.yml', '.rubocop.yml'
+      end
+    end
+  end
+end

--- a/lib/generators/money_advice_service/rubocop/templates/rubocop.yml
+++ b/lib/generators/money_advice_service/rubocop/templates/rubocop.yml
@@ -1,0 +1,45 @@
+Documentation:
+  Enabled: false
+Metrics/LineLength:
+  Max: 120
+Metrics/MethodLength:
+  Max: 15
+Style/ClassAndModuleChildren:
+  Enabled: false
+Style/CollectionMethods:
+  Enabled: false
+Style/DotPosition:
+  EnforcedStyle: leading
+Style/FormatString:
+  Enabled: false
+Style/AndOr:
+  EnforcedStyle: conditionals
+Style/Not:
+  Enabled: false
+Style/DoubleNegation:
+  Enabled: false
+Style/RaiseArgs:
+  Enabled: false
+Style/RegexpLiteral:
+  Enabled: false
+Style/StringLiterals:
+  EnforcedStyle: single_quotes
+Lint/ShadowingOuterLocalVariable:
+  Enabled: false
+AllCops:
+  Exclude:
+  - 'app/helpers/application_helper.rb'
+  - 'bin/**/*'
+  - 'config/**/*'
+  - 'db/**/*'
+  - 'Guardfile'
+  - 'lib/tasks/**/*'
+  - 'node_modules/**/*'
+  - 'script/**/*'
+  - 'spec/spec_helper.rb'
+  - 'spec/cassettes/**/*'
+  - 'spec/dummy/config/**/*.rb'
+  - 'features/**/*'
+  - 'tmp/**/*'
+  - 'vendor/**/*'
+  - 'Rakefile'

--- a/lib/mas/development_dependencies.rb
+++ b/lib/mas/development_dependencies.rb
@@ -1,8 +1,9 @@
-require 'mas/development_dependencies/version'
-
+require 'mas/development_dependencies/engine'
 require 'mas/development_dependencies/cucumber'
 require 'mas/development_dependencies/karma'
 require 'mas/development_dependencies/rspec'
+require 'mas/development_dependencies/rubocop'
+require 'mas/development_dependencies/version'
 
 module MAS
   module DevelopmentDependencies

--- a/lib/mas/development_dependencies/engine.rb
+++ b/lib/mas/development_dependencies/engine.rb
@@ -1,0 +1,9 @@
+require 'rails'
+
+module MAS
+  module DevelopmentDependencies
+    class Engine < ::Rails::Engine
+      isolate_namespace MAS::DevelopmentDependencies
+    end
+  end
+end

--- a/lib/mas/development_dependencies/rubocop.rb
+++ b/lib/mas/development_dependencies/rubocop.rb
@@ -1,0 +1,12 @@
+module MAS
+  module DevelopmentDependencies
+    module Rubocop
+      class Railtie < Rails::Railtie
+        generators do
+          require File.expand_path('../../../generators/money_advice_service/rubocop/install', __FILE__)
+        end
+      end if defined?(Rails::Railtie)
+    end
+  end
+end
+

--- a/mas-development_dependencies.gemspec
+++ b/mas-development_dependencies.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'pry-rescue'
   spec.add_dependency 'rack-livereload'
   spec.add_dependency 'rspec-rails', '>= 2.0'
+  spec.add_dependency 'rubocop'
   spec.add_dependency 'shoulda-matchers'
   spec.add_dependency 'site_prism'
   spec.add_dependency 'timecop'


### PR DESCRIPTION
As we're using rubocop for ruby linting, I thought we should add a custom generator here so that all projects can easily generate the config file we've started to use.
